### PR TITLE
"display" is not have to define in defaultDisplay

### DIFF
--- a/decorator/decorator.go
+++ b/decorator/decorator.go
@@ -8,7 +8,6 @@ type display interface {
 }
 
 type defaultDisplay struct {
-	display
 }
 
 func (self *defaultDisplay) Show(display display) string {


### PR DESCRIPTION
This code works even when I deleted "display" in defaultDisplay. But I'm sorry for that I'm a newbie for golang. Why is this defined?